### PR TITLE
FIX type definition error TS2351: This expression is not constructable

### DIFF
--- a/node-nestpay.d.ts
+++ b/node-nestpay.d.ts
@@ -82,7 +82,7 @@ export interface INestSecure3dPurchaseRequest {
     userId?: string;
 }
 
-export class NestPay {
+export default class NestPay {
     constructor(options: INestPayConfiguration | INestPayConfiguration3d);
 
     public authorize(options: INestPaymentRequest): Promise<any>;


### PR DESCRIPTION
Library exports a single default object but type definition was exporting a named export.
Importing neither default export nor named export was constructible.

Typescript usage example after this fix:
```ts
import  {default as NestPay} from 'node-nestpay';
// OR with compilerOptions.allowSyntheticDefaultImports set to true in tsconfig
// import NestPay from 'node-nestpay';

const nestpay = new NestPay({
  name: 'AKTESTAPI',
  password: 'AKBANK01',
  clientId: 100100000,
  endpoint: 'asseco',
  currency: 'TRY'
});

nestpay.purchase({
  number: '5456165456165454',
  year: '12',
  month: '12',
  cvv: '000',
  amount: '10'
}).then(/*...*/)
```